### PR TITLE
feat: unzip http stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var Busboy = require('busboy')
 var chan = require('chan')
 var BlackHoleStream = require('black-hole-stream')
+var inflate = require('inflation')
 
 var getDescriptor = Object.getOwnPropertyDescriptor
 var isArray = Array.isArray
@@ -60,7 +61,7 @@ module.exports = function (request, options) {
     onError(err)
   })
 
-  request.pipe(busboy)
+  inflate(request).pipe(busboy)
 
   // i would just put everything in an array
   // but people will complain

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ module.exports = function (request, options) {
 
   var busboy = new Busboy(options)
 
+  request = inflate(request)
   request.on('close', cleanup)
 
   busboy
@@ -61,7 +62,7 @@ module.exports = function (request, options) {
     onError(err)
   })
 
-  inflate(request).pipe(busboy)
+  request.pipe(busboy)
 
   // i would just put everything in an array
   // but people will complain

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "black-hole-stream": "~0.0.1",
     "busboy": "^0.2.8",
-    "chan": "^0.6.1"
+    "chan": "^0.6.1",
+    "inflation": "^2.0.0"
   },
   "devDependencies": {
     "co": "^4.6.0",

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ var assert = require('assert')
 var path = require('path')
 var fs = require('fs')
 var formstream = require('formstream')
-
+const zlib = require('zlib');
 var busboy = require('./')
 
 describe('Co Busboy', function () {
@@ -28,9 +28,52 @@ describe('Co Busboy', function () {
     })
   })
 
+  it('should work without autofields on gziped content', function () {
+    return co(function*(){
+      var parts = busboy(gziped())
+      var part
+      var fields = 0
+      var streams = 0
+      while (part = yield parts) {
+        if (part.length) {
+          assert.equal(part.length, 4)
+          fields++
+        } else {
+          streams++
+          part.resume()
+        }
+      }
+      assert.equal(fields, 6)
+      assert.equal(streams, 3)
+    })
+  })
+
   it('should work with autofields', function () {
     return co(function*(){
       var parts = busboy(request(), {
+        autoFields: true
+      })
+      var part
+      var fields = 0
+      var streams = 0
+      while (part = yield parts) {
+        if (part.length) {
+          fields++
+        } else {
+          streams++
+          part.resume()
+        }
+      }
+      assert.equal(fields, 0)
+      assert.equal(streams, 3)
+      assert.equal(parts.fields.length, 6)
+      assert.equal(Object.keys(parts.field).length, 3)
+    })
+  })
+
+  it('should work with autofields on gziped content', function () {
+    return co(function*(){
+      var parts = busboy(gziped(), {
         autoFields: true
       })
       var part
@@ -352,6 +395,28 @@ describe('Co Busboy', function () {
       })
     })
 
+    it('should work without autofields on gziped content', function () {
+      return co(function*(){
+        var parts = busboy(gziped())
+        var promise
+        var part
+        var fields = 0
+        var streams = 0
+        while (promise = parts(), part = yield promise) {
+          assert(promise instanceof Promise)
+          if (part.length) {
+            assert.equal(part.length, 4)
+            fields++
+          } else {
+            streams++
+            part.resume()
+          }
+        }
+        assert.equal(fields, 6)
+        assert.equal(streams, 3)
+      })
+    })
+
     it('should work with autofields', function () {
       return co(function*(){
         var parts = busboy(request(), {
@@ -374,6 +439,60 @@ describe('Co Busboy', function () {
         assert.equal(streams, 3)
         assert.equal(parts.fields.length, 6)
         assert.equal(Object.keys(parts.field).length, 3)
+      })
+    })
+
+    it('should work with autofields on gziped content', function () {
+      return co(function*(){
+        var parts = busboy(gziped(), {
+          autoFields: true
+        })
+        var promise
+        var part
+        var fields = 0
+        var streams = 0
+        while (promise = parts(), part = yield promise) {
+          assert(promise instanceof Promise)
+          if (part.length) {
+            fields++
+          } else {
+            streams++
+            part.resume()
+          }
+        }
+        assert.equal(fields, 0)
+        assert.equal(streams, 3)
+        assert.equal(parts.fields.length, 6)
+        assert.equal(Object.keys(parts.field).length, 3)
+      })
+    })
+  })
+
+  describe('with wrong encoding', function() {
+    it('will get nothing if set wrong encoding on gziped content', function () {
+      return co(function*(){
+        let stream = gziped()
+        delete stream.headers['content-encoding']
+        var parts = busboy(stream, {
+          autoFields: true
+        })
+        var promise
+        var part
+        var fields = 0
+        var streams = 0
+        while (promise = parts(), part = yield promise) {
+          assert(promise instanceof Promise)
+          if (part.length) {
+            fields++
+          } else {
+            streams++
+            part.resume()
+          }
+        }
+        assert.equal(fields, 0)
+        assert.equal(streams, 0)
+        assert.equal(parts.fields.length, 0)
+        assert.equal(Object.keys(parts.field).length, 0)
       })
     })
   })
@@ -437,5 +556,17 @@ function request() {
     '-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k--'
   ].join('\r\n'))
 
+  return stream
+}
+
+function gziped() {
+  // using `gzip` as demo, zlib support `deflate` as well
+  let stream = request()
+  const oldHeaders = stream.headers
+  stream = stream.pipe(zlib.createGzip())
+  stream.headers = {
+    ...oldHeaders,
+    'content-encoding': 'gzip',
+  }
   return stream
 }

--- a/test.js
+++ b/test.js
@@ -471,7 +471,7 @@ describe('Co Busboy', function () {
   describe('with wrong encoding', function() {
     it('will get nothing if set wrong encoding on gziped content', function () {
       return co(function*(){
-        let stream = gziped()
+        var stream = gziped()
         delete stream.headers['content-encoding']
         var parts = busboy(stream, {
           autoFields: true
@@ -559,14 +559,13 @@ function request() {
   return stream
 }
 
+
 function gziped() {
   // using `gzip` as demo, zlib support `deflate` as well
-  let stream = request()
+  var stream = request()
   const oldHeaders = stream.headers
   stream = stream.pipe(zlib.createGzip())
-  stream.headers = {
-    ...oldHeaders,
-    'content-encoding': 'gzip',
-  }
+  stream.headers = oldHeaders
+  stream.headers['content-encoding'] = 'gzip'
   return stream
 }


### PR DESCRIPTION
when the http request's body is gzip, this package should first unzip it.

like this:

```
POST / HTTP/1.1
Content-Type: multipart/form-data; charset=utf-8; boundary=__X_PAW_BOUNDARY__
Host: echo.paw.cloud
Connection: close
User-Agent: Paw/3.2.2 (Macintosh; OS X/11.2.3) GCDHTTPRequest
Content-Encoding: gzip
Content-Length: 109

`gziped(--__X_PAW_BOUNDARY__
Content-Disposition: form-data; name="sdasdasda"

asfasdasd
--__X_PAW_BOUNDARY__--)`

```

the electron crashReporter is post such a request which Content-Encoding is gzip.

--- 

dependency chain: egg -> egg-multipart -> co-busboy 